### PR TITLE
Use Larkin instead of Docker Run

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -9,11 +9,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!-- <meta name="viewport" content="width=device&#45;width, initial&#45;scale=1, shrink&#45;to&#45;fit=no" /> */} -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Docker Run (beta) | A new and better way to run Docker Containers in production" />
+    <meta name="description" content="Larkin - A new and better way to run Docker Containers in production" />
 
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Docker Run (beta) | A new and better way to run Docker Containers in production">
-    <meta property="og:description" content="A new and better way to run Docker Containers in production, which enables you to “docker run” in the clould.">
+    <meta property="og:title" content="Larkin - A new and better way to run Docker Containers in production">
+    <meta property="og:description" content="A new and better way to run Docker Containers in production, which enables you to “docker run” in the cloud.">
     <meta property="og:url" content="https://larkin.sh">
     <meta property="og:image" content="https://larkin.sh/static/images/fb-ogp.png">
 


### PR DESCRIPTION
Hi, developers. Thank you for your wonderful project!

## Changed
I just 
* used "Larkin" instead of "Docker Run (beta)" and
* fixed some typo of "cloud".

## Remaining renamings

### logos
Although you may have already noticed it, [logos in /assets](https://github.com/getlarkin/larkin/tree/4dd833dce313e61772ee7584e917aacb6db58b41/assets) should be renamed to Larkin.

### README.md
Although you may have already noticed it, "docker-run.com" is included in README.md. Maybe this should be larkin.sh or Larkin.

> Yes, docker-run.com is here: A new and better way to run Docker containers in production.

Thank you!
